### PR TITLE
Changes to Backend | Fixed Reorder Arrow Issue

### DIFF
--- a/java/src/main/java/basik/kyleyannelli/Models/Pedal.java
+++ b/java/src/main/java/basik/kyleyannelli/Models/Pedal.java
@@ -105,4 +105,8 @@ public abstract class Pedal {
     public void setLastInChain(boolean isLastInChain) {
         this.isLastInChain = isLastInChain;
     }
+
+    public boolean isOnlyPedal() {
+        return positionInBoard == 0 && isLastInChain;
+    }
 }

--- a/java/src/main/java/basik/kyleyannelli/fx/Components/BasikChorusComponent.java
+++ b/java/src/main/java/basik/kyleyannelli/fx/Components/BasikChorusComponent.java
@@ -114,7 +114,12 @@ public class BasikChorusComponent extends StackPane implements Initializable {
 
     public void setArrows(boolean doShowArrows) {
         if(doShowArrows) {
-            if(this.chorus.isLastInChain()) {
+            if(this.chorus.isOnlyPedal()) {
+                moveLeftArrowImage.setDisable(true);
+                moveLeftArrowImage.setVisible(false);
+                moveRightArrowImage.setDisable(true);
+                moveRightArrowImage.setVisible(false);
+            } else if(this.chorus.isLastInChain()) {
                 moveLeftArrowImage.setDisable(false);
                 moveLeftArrowImage.setVisible(true);
             } else if(this.chorus.getPositionInBoard() == 0) {

--- a/java/src/main/java/basik/kyleyannelli/fx/Components/BasikDelayComponent.java
+++ b/java/src/main/java/basik/kyleyannelli/fx/Components/BasikDelayComponent.java
@@ -85,7 +85,12 @@ public class BasikDelayComponent extends StackPane implements Initializable {
 
     public void setArrows(boolean doShowArrows) {
         if(doShowArrows) {
-            if(this.delay.isLastInChain()) {
+            if(this.delay.isOnlyPedal()) {
+                moveLeftArrowImage.setDisable(true);
+                moveLeftArrowImage.setVisible(false);
+                moveRightArrowImage.setDisable(true);
+                moveRightArrowImage.setVisible(false);
+            } else if(this.delay.isLastInChain()) {
                 moveLeftArrowImage.setDisable(false);
                 moveLeftArrowImage.setVisible(true);
             } else if(this.delay.getPositionInBoard() == 0) {

--- a/java/src/main/java/basik/kyleyannelli/fx/Components/BasikDistortionComponent.java
+++ b/java/src/main/java/basik/kyleyannelli/fx/Components/BasikDistortionComponent.java
@@ -102,7 +102,12 @@ public class BasikDistortionComponent extends StackPane implements Initializable
 
     public void setArrows(boolean doShowArrows) {
         if(doShowArrows) {
-            if(this.distortion.isLastInChain()) {
+            if(this.distortion.isOnlyPedal()) {
+                moveLeftArrowImage.setDisable(true);
+                moveLeftArrowImage.setVisible(false);
+                moveRightArrowImage.setDisable(true);
+                moveRightArrowImage.setVisible(false);
+            } else if(this.distortion.isLastInChain()) {
                 moveLeftArrowImage.setDisable(false);
                 moveLeftArrowImage.setVisible(true);
             } else if(this.distortion.getPositionInBoard() == 0) {

--- a/java/src/main/java/basik/kyleyannelli/fx/Components/BasikReverbComponent.java
+++ b/java/src/main/java/basik/kyleyannelli/fx/Components/BasikReverbComponent.java
@@ -111,7 +111,12 @@ public class BasikReverbComponent extends StackPane implements Initializable {
 
     public void setArrows(boolean doShowArrows) {
         if(doShowArrows) {
-            if(this.reverb.isLastInChain()) {
+            if(this.reverb.isOnlyPedal()) {
+                moveLeftArrowImage.setDisable(true);
+                moveLeftArrowImage.setVisible(false);
+                moveRightArrowImage.setDisable(true);
+                moveRightArrowImage.setVisible(false);
+            } else if(this.reverb.isLastInChain()) {
                 moveLeftArrowImage.setDisable(false);
                 moveLeftArrowImage.setVisible(true);
             } else if(this.reverb.getPositionInBoard() == 0) {

--- a/python/python/live_audio.py
+++ b/python/python/live_audio.py
@@ -47,7 +47,7 @@ def start():
     selected_output_device: int = sync_get_data(output_url, -1)
 
     global cli_url
-    with AudioStream(buffer_size=2048, input_device_name=str(set_input_device(selected_input_device)),
+    with AudioStream(buffer_size=1024, input_device_name=str(set_input_device(selected_input_device)),
                      output_device_name=str(set_output_device(selected_output_device)), allow_feedback=True) as stream:
         handle_api_stream(stream)
 

--- a/python/python/live_audio.py
+++ b/python/python/live_audio.py
@@ -22,7 +22,7 @@ effect_url = url + "/effect"
 pedalboard_url = url + "/pedalboard"
 remove_pos_url = url + "/remove-pos"
 
-distortion_amp = [Compressor(ratio=1000), Gain(gain_db=20), Clipping(threshold_db=-10), HighpassFilter(cutoff_frequency_hz=250),
+distortion_amp = [Compressor(), Gain(gain_db=20), Clipping(threshold_db=-10), HighpassFilter(cutoff_frequency_hz=250),
                   Gain(gain_db=-15), Distortion(drive_db=15.1), Gain(gain_db=20), Gain(gain_db=-15), Distortion(drive_db=15.1),
                   Gain(gain_db=20), Gain(gain_db=-15),
                   Distortion(drive_db=15.1), Gain(gain_db=-10), Gain(gain_db=20), Gain(gain_db=-15)]


### PR DESCRIPTION
### Python
- Changed default bitrate to 1024, *this should be adjustable in a future release*.
- Changed distortion amp compression to default value for Pedalboard.
### Java
- Added isOnlyPedal() method to abstract class Pedals
- Fixed reordering issue in GUI where only one pedal would be on board but the arrows would show.